### PR TITLE
feat(ci): add file-size budget check per ADR D-11 (report-only)

### DIFF
--- a/.github/workflows/file-size-check.yml
+++ b/.github/workflows/file-size-check.yml
@@ -1,0 +1,59 @@
+name: File-Size Budget Check
+
+# ADR 0001 D-11 — enforce a soft target of 350 lines and a hard cap of 700
+# lines on production .go files (test files exempt).
+#
+# This workflow runs in REPORT-ONLY mode during P0 of the v2 refactor
+# (per ADR §4.P0). It will be flipped to BLOCKING at the start of P1 by
+# changing the script flag below. Findings are published to the GitHub
+# Step Summary so authors and reviewers see them on every PR.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "**.go"
+      - "scripts/lint/check-file-size.sh"
+      - ".github/workflows/file-size-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  file-size-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run file-size budget check (report-only)
+        id: check
+        run: |
+          set +e
+          ./scripts/lint/check-file-size.sh --report-only | tee check-output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Publish results to step summary
+        if: always()
+        run: |
+          {
+            echo "## ADR 0001 D-11 — File-Size Budget Check"
+            echo ""
+            echo "**Mode:** \`report-only\` (will flip to \`--blocking\` at the start of P1 of the v2 refactor)"
+            echo ""
+            echo "**Budgets:** soft target **350** lines · hard cap **700** lines · \`_test.go\` exempt"
+            echo ""
+            echo '```text'
+            cat check-output.txt
+            echo '```'
+            echo ""
+            echo "_See [ADR 0001 §D-11](../blob/main/docs/adr/0001-v2-total-refactor.md) for waiver process and split plan._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: file-size-check
+          path: check-output.txt
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Redis In-Memory Replica Library Makefile
 
 .DEFAULT_GOAL := help
-.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare
+.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare file-size-check file-size-check-blocking
 
 # Go parameters
 GOCMD=go
@@ -189,3 +189,8 @@ security-deps: ## Check dependencies for vulnerabilities
 	@go mod verify
 	@go mod tidy
 	@go list -m all
+file-size-check: ## Check .go file sizes against ADR D-11 budget (report-only by default)
+	@./scripts/lint/check-file-size.sh --report-only
+
+file-size-check-blocking: ## Check .go file sizes against ADR D-11 budget (blocking — fails on hard cap violations)
+	@./scripts/lint/check-file-size.sh --blocking

--- a/scripts/lint/check-file-size.sh
+++ b/scripts/lint/check-file-size.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# check-file-size.sh — enforce ADR 0001 D-11 file-size budget on .go files.
+#
+# Soft target: 350 lines (warn; informational only)
+# Hard cap:    700 lines (fail in blocking mode; warn in report-only mode)
+#
+# `_test.go` files are exempt — table-driven tests and fixture data
+# legitimately grow them. Production code does not get the same indulgence.
+#
+# Modes:
+#   --report-only (default): always exit 0; print findings to stdout.
+#                            Use this in P0 of the v2 refactor.
+#   --blocking:              exit non-zero when any file exceeds the hard cap.
+#                            Use this from P1 onward (per ADR §4.P0/P1).
+#
+# Waivers: a file may carry `//nolint:filesize` on its package-level doc
+# comment to opt out, but must include a tracking issue and a target
+# removal date per ADR D-11.
+
+set -euo pipefail
+
+SOFT=350
+HARD=700
+MODE="report-only"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report-only) MODE="report-only"; shift ;;
+    --blocking)    MODE="blocking"; shift ;;
+    --soft)        SOFT="$2"; shift 2 ;;
+    --hard)        HARD="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '3,22p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Files to scan: every .go that is not a _test.go, not under .git, .claude,
+# vendor, or examples. Examples are intentionally exempt — they exist to
+# demonstrate usage, not to be production-grade.
+mapfile -t FILES < <(
+  find . \
+    -type f -name '*.go' \
+    -not -name '*_test.go' \
+    -not -path './.git/*' \
+    -not -path './.claude/*' \
+    -not -path './vendor/*' \
+    -not -path './examples/*' \
+    -print | sort
+)
+
+over_soft=()
+over_hard=()
+waived=()
+
+for f in "${FILES[@]}"; do
+  lines=$(wc -l < "$f" | tr -d ' ')
+  if grep -q '//nolint:filesize' "$f"; then
+    waived+=("${lines} ${f}")
+    continue
+  fi
+  if [ "$lines" -gt "$HARD" ]; then
+    over_hard+=("${lines} ${f}")
+  elif [ "$lines" -gt "$SOFT" ]; then
+    over_soft+=("${lines} ${f}")
+  fi
+done
+
+print_table() {
+  # $1 = label, $2..$N = "lines path" rows
+  local label="$1"; shift
+  # Sort descending by first field (numeric)
+  printf '%s\n' "$@" | sort -rn | awk '{ printf "    %6d  %s\n", $1, $2 }'
+}
+
+echo "==================================================================="
+echo "  ADR 0001 D-11 — File-Size Budget Check (${MODE} mode)"
+echo "  Soft target: ${SOFT} lines    Hard cap: ${HARD} lines"
+echo "  Excluded: *_test.go, ./.git, ./.claude, ./vendor, ./examples"
+echo "==================================================================="
+echo
+
+if [ "${#over_hard[@]}" -eq 0 ] && [ "${#over_soft[@]}" -eq 0 ] && [ "${#waived[@]}" -eq 0 ]; then
+  echo "OK — every production .go file is within the soft target (${SOFT} lines)."
+  exit 0
+fi
+
+if [ "${#over_hard[@]}" -gt 0 ]; then
+  echo ">>> OVER HARD CAP (${HARD} lines)"
+  echo "    These files MUST be split. See ADR §4 for planned phase."
+  print_table "hard" "${over_hard[@]}"
+  echo
+fi
+
+if [ "${#over_soft[@]}" -gt 0 ]; then
+  echo ">>> OVER SOFT TARGET (${SOFT} lines) but within hard cap"
+  echo "    Consider splitting when convenient; not blocking."
+  print_table "soft" "${over_soft[@]}"
+  echo
+fi
+
+if [ "${#waived[@]}" -gt 0 ]; then
+  echo ">>> WAIVED (//nolint:filesize present)"
+  print_table "waived" "${waived[@]}"
+  echo
+fi
+
+if [ "$MODE" = "blocking" ] && [ "${#over_hard[@]}" -gt 0 ]; then
+  echo "FAIL: ${#over_hard[@]} file(s) exceed the hard cap (${HARD} lines)." >&2
+  exit 1
+fi
+
+echo "Report-only mode — no failure raised."
+echo "Flip to --blocking from P1 onward (per ADR D-11)."
+exit 0


### PR DESCRIPTION
## Summary

First gate of **P0** from [ADR 0001](docs/adr/0001-v2-total-refactor.md). Implements **D-11** — soft target **350** lines, hard cap **700** lines on production `.go` files (`_test.go` exempt).

Runs in **REPORT-ONLY** mode during P0 (per ADR §4.P0). Will be flipped to **BLOCKING** at the start of P1 by changing one flag in `.github/workflows/file-size-check.yml`. The three pre-existing hard-cap violators are mapped to their planned split phases in the ADR.

## What lands here

| File | Purpose |
|------|---------|
| `scripts/lint/check-file-size.sh` | Portable bash script. Two modes (`--report-only` / `--blocking`), `--soft` / `--hard` overrides, `//nolint:filesize` waiver mechanism. |
| `Makefile` | `make file-size-check` (report-only) and `make file-size-check-blocking` for local developer use. Visible in `make help`. |
| `.github/workflows/file-size-check.yml` | CI workflow on push-to-main and PRs touching `.go`, the script, or this workflow. Publishes findings to the **GitHub Step Summary** so reviewers see them inline. Uploads `check-output.txt` as a 30-day artifact. |

## Excluded paths

`./.git`, `./.claude`, `./vendor`, `./examples` — examples are exempt by design (and the ADR will prune the directory anyway, per Q-5).

## Current baseline (informational)

Matches what the ADR predicted:

**OVER HARD CAP (>700 lines)** — must be split, planned phase noted:
```
  1446  ./replication/client.go   (split planned in P1)
  1140  ./server/server.go        (split planned in P5)
   994  ./storage/memory.go       (split planned in P3a)
```

**OVER SOFT TARGET (>350, ≤700)** — informational, not blocking:
```
   660  ./replication/rdb.go
   528  ./options.go
   469  ./protocol/reader.go
   414  ./lua/engine.go
   377  ./replica.go
```

## Test plan

- [ ] CI `file-size-check` (this new workflow) green — should publish a summary listing the 3 hard-cap and 5 soft-target violators above, exit 0 (report-only).
- [ ] Existing CI checks (test, lint, e2e, redis-compat, benchmarks, security) all green — workflow is additive, doesn't touch source.
- [ ] `make file-size-check` runs locally and produces the same listing.
- [ ] `make help` shows both new targets.

## Risk

**None.** The script never fails CI in P0. The Makefile targets are additive. The three hard-cap violators are pre-existing and already tracked by the ADR. This PR's value is making the budget **visible to reviewers** on every PR, so further drift is caught early.

## Next P0 items (separate PRs)

- `make baseline` (capture benchmark baseline + CPU/mem profiles + escape-analysis text)
- `make escape-analysis` (diff against baseline on hot-file changes)
- `go vet -fieldalignment` (struct-field alignment vet)
- `bench-regression.yml` (CI gate for benchmark regression vs baseline)
- `benchstat-required` PR-body lint
- Re-collect baselines on Go 1.26.3 (post-P0 infra completion)