### PR TITLE
feat(ci): add struct field alignment check per ADR D-10 §10.5 (report-only)

### DIFF
--- a/.github/workflows/fieldalignment.yml
+++ b/.github/workflows/fieldalignment.yml
@@ -1,0 +1,71 @@
+name: Struct Field Alignment Check
+
+# ADR 0001 D-10 §10.5 — surface struct misalignments that waste memory
+# on hot paths. Report-only during P0; fixes land per-PR, per-subsystem,
+# with `benchstat` before/after, as part of P3/P3a/P3b of the v2 refactor.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "**.go"
+      - "scripts/lint/check-fieldalignment.sh"
+      - ".github/workflows/fieldalignment.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  fieldalignment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.3"
+
+      - name: Cache Go modules and tool binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-fa-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-fa-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run fieldalignment (report-only)
+        id: check
+        run: |
+          set +e
+          ./scripts/lint/check-fieldalignment.sh --report-only | tee fa-output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Publish results to step summary
+        if: always()
+        run: |
+          {
+            echo "## ADR 0001 D-10 §10.5 — Struct Field Alignment"
+            echo ""
+            echo "**Mode:** \`report-only\` (fixes land in P3/P3a/P3b per-subsystem with benchstat before/after)"
+            echo ""
+            echo '```text'
+            cat fa-output.txt
+            echo '```'
+            echo ""
+            echo "_See [ADR 0001 D-10 §10.5](../blob/main/docs/adr/0001-v2-total-refactor.md) for the fix strategy._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fieldalignment
+          path: fa-output.txt
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Redis In-Memory Replica Library Makefile
 
 .DEFAULT_GOAL := help
-.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare file-size-check file-size-check-blocking
+.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare file-size-check file-size-check-blocking fieldalignment fieldalignment-blocking
 
 # Go parameters
 GOCMD=go
@@ -194,3 +194,9 @@ file-size-check: ## Check .go file sizes against ADR D-11 budget (report-only by
 
 file-size-check-blocking: ## Check .go file sizes against ADR D-11 budget (blocking — fails on hard cap violations)
 	@./scripts/lint/check-file-size.sh --blocking
+
+fieldalignment: ## Check struct field alignment per ADR D-10 §10.5 (report-only)
+	@./scripts/lint/check-fieldalignment.sh --report-only
+
+fieldalignment-blocking: ## Check struct field alignment per ADR D-10 §10.5 (blocking)
+	@./scripts/lint/check-fieldalignment.sh --blocking

--- a/scripts/lint/check-fieldalignment.sh
+++ b/scripts/lint/check-fieldalignment.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# check-fieldalignment.sh — run golang.org/x/tools fieldalignment on the
+# project's production .go packages.
+#
+# Per ADR 0001 D-10 §10.5: "struct field alignment vet" is a P0 pre-flight
+# gate. Misaligned struct layouts waste memory on the hot path (Value,
+# request/response types, replication state). This script surfaces
+# violations; it does NOT auto-fix.
+#
+# Modes:
+#   --report-only (default): always exit 0; print findings.
+#                            Use during P0 of the v2 refactor.
+#   --blocking:              exit non-zero on ANY production misalignment.
+#                            Reserved for later phases.
+#
+# Fixes land per-PR, per-subsystem, with `benchstat` before/after, as
+# part of P3/P3a/P3b of the v2 refactor.
+
+set -euo pipefail
+
+MODE="report-only"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report-only) MODE="report-only"; shift ;;
+    --blocking)    MODE="blocking"; shift ;;
+    -h|--help) sed -n '3,19p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+FA_BIN="${FA_BIN:-${HOME}/go/bin/fieldalignment}"
+if ! [ -x "$FA_BIN" ]; then
+  echo "Installing fieldalignment..."
+  go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
+fi
+
+PKGS=(
+  "."
+  "./storage/..."
+  "./protocol/..."
+  "./lua/..."
+  "./replication/..."
+  "./server/..."
+)
+
+echo "==================================================================="
+echo "  ADR 0001 D-10 §10.5 — Struct Field Alignment (${MODE} mode)"
+echo "  Scanning: ${PKGS[*]}"
+echo "==================================================================="
+echo
+
+findings_file=$(mktemp)
+trap 'rm -f "$findings_file"' EXIT
+
+set +e
+"$FA_BIN" "${PKGS[@]}" 2> "$findings_file"
+fa_exit=$?
+set -e
+
+if [ ! -s "$findings_file" ]; then
+  echo "OK — fieldalignment found no misalignments."
+  exit 0
+fi
+
+prod=$(grep -v "_test\.go:" "$findings_file" || true)
+tests=$(grep "_test\.go:" "$findings_file" || true)
+prod_count=$(printf '%s\n' "$prod" | grep -c . || true)
+test_count=$(printf '%s\n' "$tests" | grep -c . || true)
+
+if [ -n "$prod" ]; then
+  echo ">>> PRODUCTION CODE — struct alignment can be improved"
+  echo "$prod" | sed 's|^|    |'
+  echo
+  echo "    Total production findings: ${prod_count}"
+  echo
+fi
+
+if [ -n "$tests" ]; then
+  echo ">>> TEST CODE (informational; not a P0 priority)"
+  echo "$tests" | sed 's|^|    |'
+  echo
+  echo "    Total test findings: ${test_count}"
+  echo
+fi
+
+echo "Fix strategy (per ADR P3/P3a/P3b):"
+echo "  - One PR per subsystem (storage -> protocol -> lua -> replication -> server)"
+echo "  - Run benchstat before/after on the touched package"
+echo "  - Verify zero allocation regression on hot paths (ADR D-10 §10.1)"
+echo
+
+if [ "$MODE" = "blocking" ] && [ "$prod_count" -gt 0 ]; then
+  echo "FAIL: ${prod_count} production-code misalignment(s) detected." >&2
+  exit 1
+fi
+
+echo "Report-only mode — no failure raised (fa exit was ${fa_exit})."
+exit 0


### PR DESCRIPTION
> **Stacked PR:** base is \`chore/p0-file-size-check\` (PR #34) to keep the diff focused on just the fieldalignment infra. **Will rebase onto \`main\` after PR #34 lands.**

## Summary

Second gate of **P0** from [ADR 0001](docs/adr/0001-v2-total-refactor.md). Surfaces struct misalignments that waste memory on hot paths (`Value`, request/response types, replication state, server connection state).

Runs in **REPORT-ONLY** mode during P0. Fixes land per-PR, per-subsystem, with \`benchstat\` before/after, as part of P3/P3a/P3b of the v2 refactor.

## What lands here

| File | Purpose |
|------|---------|
| \`scripts/lint/check-fieldalignment.sh\` | Installs \`golang.org/x/tools/.../fieldalignment\` on first run (idempotent), scans production packages, separates prod vs. \`_test.go\` findings. |
| \`Makefile\` | \`make fieldalignment\` (report-only) and \`make fieldalignment-blocking\` (reserved for later phases). |
| \`.github/workflows/fieldalignment.yml\` | New CI workflow on push-to-main and PRs touching \`.go\`. Publishes findings to Step Summary; uploads \`fa-output.txt\` as 30-day artifact. |

## Current baseline (informational)

- **29 production-code findings** — biggest wins are in:
  - \`replication/client.go\` — multiple structs, up to 48-byte savings per type
  - \`server/server.go\` — 2 structs, ~32 bytes savings combined
  - \`lua/engine.go\` — 1 struct, 48-byte savings
- **16 \`_test.go\` findings** — informational only.

## Why report-only, not auto-fix

Reordering fields interacts with:
1. \`sync/atomic\` alignment requirements on 32-bit platforms
2. \`unsafe.Pointer\` usage (none currently identified, but worth checking per subsystem)
3. Benchmark allocations (the whole point of D-10 is that perf must be measured, not assumed)

Each fix lands in its own PR with \`benchstat\` evidence, following ADR §10.6 per-phase gates.

## Test plan

- [ ] CI \`fieldalignment\` (new workflow) green — should publish summary with 29 prod / 16 test findings, exit 0 (report-only).
- [ ] All other CI checks remain green (additive workflow, no source changes).
- [ ] \`make fieldalignment\` runs locally and produces the same output.

## Risk

**None.** Script never fails CI in P0. Makefile targets are additive. The 29 findings are pre-existing — this PR's value is making them **visible to reviewers** on every PR, so further drift is caught early and the v2 P3 phase has a clear target list.

## Next P0 items (separate PRs)

- \`make baseline\` — capture benchmark + CPU/mem profiles + escape-analysis baseline
- \`make escape-analysis\` — diff against baseline
- \`bench-regression.yml\` — CI gate for benchmark regression vs baseline
- \`benchstat-required\` PR-body lint
- Re-collect baselines on Go 1.26.3