### PR TITLE
feat(perf): add make baseline / make escape-analysis per ADR D-10 §10.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ test_output.txt
 artifacts/
 *.prof
 *.pprof
+
+# ADR 0001 D-10 §10.4 — local baseline snapshots (not version-controlled;
+# baselines for CI live in workflow artifacts, not the repo)
+artifacts/baseline/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Redis In-Memory Replica Library Makefile
 
 .DEFAULT_GOAL := help
-.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare file-size-check file-size-check-blocking fieldalignment fieldalignment-blocking
+.PHONY: help build test lint clean examples install-tools benchmark coverage docs security-audit security-install security-scan security-static security-deps bench-all profile bench-compare file-size-check file-size-check-blocking fieldalignment fieldalignment-blocking baseline escape-analysis
 
 # Go parameters
 GOCMD=go
@@ -200,3 +200,9 @@ fieldalignment: ## Check struct field alignment per ADR D-10 §10.5 (report-only
 
 fieldalignment-blocking: ## Check struct field alignment per ADR D-10 §10.5 (blocking)
 	@./scripts/lint/check-fieldalignment.sh --blocking
+
+baseline: ## Capture a performance baseline snapshot (benchmarks + escape analysis + env) per ADR D-10 §10.4
+	@./scripts/perf/baseline.sh
+
+escape-analysis: ## Diff current escape-analysis output against the latest baseline
+	@./scripts/perf/escape-analysis.sh

--- a/scripts/perf/baseline.sh
+++ b/scripts/perf/baseline.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# baseline.sh — capture a complete performance baseline snapshot per
+# ADR 0001 D-10 §10.4: benchmarks (benchstat-ready), escape-analysis
+# text for hot files, and a record of the toolchain/runner state.
+#
+# Output: artifacts/baseline/<TIMESTAMP>/
+#   - bench-storage.txt         go test -bench results for storage
+#   - bench-protocol.txt        ... for protocol
+#   - bench-lua.txt             ... for lua
+#   - bench-replication.txt     ... for replication
+#   - bench-root.txt            ... for the root package (DatabaseInfo benches;
+#                                replication benches skip without Redis)
+#   - bench-all.txt             concatenation of the above, ready for benchstat
+#   - escape-analysis.txt       go build -gcflags=-m output for hot packages
+#   - env.txt                   go version, GOMAXPROCS, kernel, CPU, memory
+#
+# Usage:
+#   ./scripts/perf/baseline.sh           # default: count=5 benchtime=3s
+#   ./scripts/perf/baseline.sh 3 2s      # count=3 benchtime=2s (quick)
+#
+# Recommended invocation from CI / release-prep is `make baseline`.
+# Re-running this OVERWRITES the latest symlink but never deletes prior
+# timestamped snapshots — keep all historical baselines for benchstat.
+
+set -euo pipefail
+
+COUNT="${1:-5}"
+BENCHTIME="${2:-${BENCHTIME:-3s}}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUT_BASE="artifacts/baseline"
+OUT_DIR="${OUT_BASE}/${TIMESTAMP}"
+
+mkdir -p "${OUT_DIR}"
+
+echo "==================================================================="
+echo "  Baseline snapshot — ${TIMESTAMP}"
+echo "  count=${COUNT}, benchtime=${BENCHTIME}, GOMAXPROCS=${GOMAXPROCS:-default}"
+echo "==================================================================="
+
+# Capture environment
+{
+  echo "## Environment"
+  echo "Date:        $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Hostname:    $(hostname 2>/dev/null || echo n/a)"
+  echo "OS:          $(uname -srm)"
+  echo "Go version:  $(go version)"
+  echo "GOMAXPROCS:  ${GOMAXPROCS:-default}"
+  echo "CPU:         $(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | sed 's/.*: //' || echo n/a)"
+  echo "Cores:       $(nproc 2>/dev/null || echo n/a)"
+  echo "Memory:      $(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2/1024 " MB"}' || echo n/a)"
+  echo "Git commit:  $(git rev-parse HEAD 2>/dev/null || echo n/a)"
+  echo "Git status:  $(git diff --stat 2>/dev/null | tail -1 || echo n/a)"
+} > "${OUT_DIR}/env.txt"
+cat "${OUT_DIR}/env.txt"
+echo
+
+# Benchmark each production package separately so a flaky/slow one doesn't
+# torpedo the rest. We collect everything; presence of failures is visible
+# from the per-file content, not from this script's exit code.
+PKGS=(
+  "storage:./storage/"
+  "protocol:./protocol/"
+  "lua:./lua/"
+  "replication:./replication/"
+  "root:."
+)
+
+for entry in "${PKGS[@]}"; do
+  label="${entry%%:*}"
+  pkg="${entry#*:}"
+  out="${OUT_DIR}/bench-${label}.txt"
+  echo "→ Benchmarking ${pkg}  (${label})"
+  if go test -bench=. -run=^$ -benchmem -count="${COUNT}" -benchtime="${BENCHTIME}" "${pkg}" \
+       > "${out}" 2>&1; then
+    n=$(grep -c '^Benchmark' "${out}" || true)
+    echo "  ✓ ${n} measurement lines → ${out}"
+  else
+    echo "  ✗ failed — see ${out}"
+  fi
+done
+
+# Concatenate into a single benchstat-ready file
+cat "${OUT_DIR}"/bench-*.txt > "${OUT_DIR}/bench-all.txt"
+echo
+echo "→ Combined: ${OUT_DIR}/bench-all.txt ($(grep -c '^Benchmark' "${OUT_DIR}/bench-all.txt" || true) measurement lines)"
+
+# Escape analysis on hot files — `-gcflags="-m=2"` emits inlining and
+# escape decisions. We capture the WHOLE build output, then store it for
+# later diffing by `make escape-analysis` (which is the diff target).
+echo
+echo "→ Capturing escape analysis for hot packages"
+go build -gcflags="-m=2" ./storage/... ./protocol/... ./lua/... ./replication/... ./server/... ./ \
+  > "${OUT_DIR}/escape-analysis.txt" 2>&1 || true
+echo "  ✓ $(wc -l < "${OUT_DIR}/escape-analysis.txt") lines → ${OUT_DIR}/escape-analysis.txt"
+
+# Symlink latest for convenience
+ln -sfn "${TIMESTAMP}" "${OUT_BASE}/latest"
+echo
+echo "==================================================================="
+echo "  Baseline captured at ${OUT_DIR}"
+echo "  Latest symlink: ${OUT_BASE}/latest -> ${TIMESTAMP}"
+echo "==================================================================="
+echo
+echo "Next steps:"
+echo "  - Compare a current run: make bench-compare base=${OUT_DIR}/bench-all.txt head=current.txt"
+echo "  - Diff escape analysis : make escape-analysis (diffs current vs ${OUT_BASE}/latest)"
+echo

--- a/scripts/perf/escape-analysis.sh
+++ b/scripts/perf/escape-analysis.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# escape-analysis.sh — produce a CURRENT escape-analysis snapshot and
+# diff it against the most recent baseline (artifacts/baseline/latest/
+# escape-analysis.txt). Per ADR 0001 D-10 §10.4.
+#
+# Designed for fast iteration during a PR: run before and after a change
+# in a hot package to see which allocations moved from stack to heap
+# (or, ideally, the other way).
+#
+# Usage:
+#   ./scripts/perf/escape-analysis.sh                    # diff vs latest baseline
+#   ./scripts/perf/escape-analysis.sh path/to/old.txt    # diff vs a specific file
+#
+# Exit code is 0 even if there are differences — this is informational.
+# `bench-regression.yml` (later PR) will gate on benchstat instead.
+
+set -euo pipefail
+
+BASELINE="${1:-artifacts/baseline/latest/escape-analysis.txt}"
+CURRENT_DIR="/tmp/escape-analysis-current"
+mkdir -p "${CURRENT_DIR}"
+CURRENT_FILE="${CURRENT_DIR}/escape-analysis.txt"
+
+if [ ! -f "${BASELINE}" ]; then
+  echo "Baseline file not found: ${BASELINE}" >&2
+  echo "Run \`make baseline\` first to capture one." >&2
+  exit 2
+fi
+
+echo "Capturing current escape-analysis snapshot..."
+go build -gcflags="-m=2" ./storage/... ./protocol/... ./lua/... ./replication/... ./server/... ./ \
+  > "${CURRENT_FILE}" 2>&1 || true
+echo "  → ${CURRENT_FILE} ($(wc -l < "${CURRENT_FILE}") lines)"
+echo
+
+echo "==================================================================="
+echo "  Escape-analysis diff (vs ${BASELINE})"
+echo "==================================================================="
+
+# Show summary stats first (count of "escapes to heap" lines)
+base_heap=$(grep -c 'escapes to heap' "${BASELINE}" || true)
+curr_heap=$(grep -c 'escapes to heap' "${CURRENT_FILE}" || true)
+delta=$(( curr_heap - base_heap ))
+
+echo "  'escapes to heap' lines:"
+echo "    baseline: ${base_heap}"
+echo "    current : ${curr_heap}"
+if [ "${delta}" -gt 0 ]; then
+  echo "    delta   : +${delta}  ⚠ MORE escapes than baseline"
+elif [ "${delta}" -lt 0 ]; then
+  echo "    delta   : ${delta}   ✓ FEWER escapes than baseline"
+else
+  echo "    delta   : 0          (no change)"
+fi
+echo
+
+# Unified diff for the human reviewer
+if diff -u "${BASELINE}" "${CURRENT_FILE}" > /tmp/escape-diff.patch 2>&1; then
+  echo "OK — no differences in escape analysis output."
+else
+  echo "Differences detected. Unified diff saved to /tmp/escape-diff.patch"
+  echo
+  echo "First 80 lines of the diff:"
+  head -80 /tmp/escape-diff.patch
+  echo
+  echo "(See /tmp/escape-diff.patch for the full diff.)"
+fi


### PR DESCRIPTION
## Summary

Third P0 PR. Delivers the two **opt-in** developer tools that the rest of P0 depends on:

1. **\`make baseline\`** — captures a reproducible snapshot of bench numbers + escape behaviour + env metadata.
2. **\`make escape-analysis\`** — fast diff target showing what a change moved.

**No CI gating yet** — that lands with \`bench-regression.yml\` in the next P0 PR.

## What lands here

| File | Purpose |
|------|---------|
| \`scripts/perf/baseline.sh\` | Captures \`artifacts/baseline/<TIMESTAMP>/\` with per-package bench files (\`bench-{storage,protocol,lua,replication,root}.txt\`), a combined \`bench-all.txt\` ready for benchstat, an \`escape-analysis.txt\` from \`go build -gcflags=\"-m=2\"\`, and an \`env.txt\` with toolchain/CPU/memory/git SHA. Maintains an \`artifacts/baseline/latest\` symlink. Defaults: \`count=5 benchtime=3s\`. |
| \`scripts/perf/escape-analysis.sh\` | Captures CURRENT escape-analysis to \`/tmp/\`, diffs against \`artifacts/baseline/latest/\`, prints \`escapes to heap\` delta + unified diff. Always exits 0 (informational). |
| \`Makefile\` | \`make baseline\` and \`make escape-analysis\` targets, visible in \`make help\`. |
| \`.gitignore\` | Adds \`artifacts/baseline/\` — local snapshots stay local. |

## Smoke validation

\`\`\`
./scripts/perf/baseline.sh 1 500ms        # quick run
→ 221 measurement lines, 14 639-line escape-analysis dump in ~90 s
./scripts/perf/escape-analysis.sh         # immediate re-run
→ delta=0; "no differences in escape analysis output"
\`\`\`

## Test plan

- [ ] CI green (additive change; no source changes; \`file-size-check\` and \`fieldalignment\` workflows from #34/#35 stay green)
- [ ] \`make help\` shows both new targets
- [ ] \`make baseline\` runs locally to completion in <1 min with low \`count\`
- [ ] \`make escape-analysis\` reports delta=0 immediately after \`make baseline\`

## Risk

**None.** No source changes. Targets are opt-in for now. Local-only artifact directory is gitignored.

## Why baselines stay out of the repo

Baselines that need to be shared between developers / CI should live in **CI workflow artifacts** (captured by the upcoming \`bench-regression.yml\`) and in **\`docs/baseline-metrics.md\`** (re-collected per release). Putting them in the repo would explode the working-tree size and pollute git history with binary-ish content.

## Remaining P0 (separate PRs)

- \`bench-regression.yml\` — CI workflow that runs the baseline against the PR's HEAD and gates via \`bench-compare\` against a pinned \`main\` baseline.
- \`benchstat-required\` PR-body lint.
- Re-collecting \`docs/baseline-metrics.md\` on Go 1.26.3.